### PR TITLE
Port Pachinko to current plugin version

### DIFF
--- a/game-04/main.tscn
+++ b/game-04/main.tscn
@@ -1,484 +1,298 @@
-[gd_scene load_steps=166 format=3 uid="uid://b4wh31l7g4n6a"]
+[gd_scene load_steps=102 format=3 uid="uid://b4wh31l7g4n6a"]
 
 [ext_resource type="PackedScene" uid="uid://crjhuj7jjpqkg" path="res://game-04/ball.tscn" id="1_afi7h"]
 [ext_resource type="PackedScene" uid="uid://q8ko63dmnn0r" path="res://game-04/pin.tscn" id="1_m56sh"]
 [ext_resource type="Texture2D" uid="uid://dmnyl2fkfvck4" path="res://game-04/Images/wall.svg" id="1_sperd"]
+[ext_resource type="Script" path="res://addons/block_code/serialization/block_serialization_tree.gd" id="2_cvyqc"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="4_54tis"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/variable_definition.gd" id="4_oqjhm"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_serialization.gd" id="5_16m7n"]
-[ext_resource type="Script" path="res://addons/block_code/serialization/block_serialized_properties.gd" id="6_8anhq"]
-[ext_resource type="Script" path="res://addons/block_code/ui/block_canvas/option_data.gd" id="7_ipmj4"]
 [ext_resource type="Texture2D" uid="uid://va6vbooexk" path="res://game-04/Images/goal.svg" id="8_r3ewt"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_script_serialization.gd" id="8_wkl7e"]
-[ext_resource type="Script" path="res://addons/block_code/ui/block_canvas/variable_resource.gd" id="9_rblu1"]
+[ext_resource type="Script" path="res://addons/block_code/serialization/value_block_serialization.gd" id="9_jnins"]
 
-[sub_resource type="Resource" id="Resource_4gw1y"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_xqhad"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"file_path": "res://game-04/Sounds/Bump.ogg",
-"name": "Bump"
-}]]
-
-[sub_resource type="Resource" id="Resource_oaqe4"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_Bumps"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "Set Bumps to {value: INT}"], ["statement", "Bumps = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": 0
-}]]
-
-[sub_resource type="Resource" id="Resource_x0eoh"]
-script = ExtResource("5_16m7n")
-name = &"set_var_Bumps"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_oaqe4")
-
-[sub_resource type="Resource" id="Resource_s730d"]
+[sub_resource type="Resource" id="Resource_ojsiq"]
 script = ExtResource("5_16m7n")
 name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_x0eoh")]]
-block_serialized_properties = SubResource("Resource_xqhad")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"file_path": "res://game-04/Sounds/Bump.ogg",
+"name": "Bump"
+}
 
-[sub_resource type="Resource" id="Resource_acsgj"]
+[sub_resource type="Resource" id="Resource_yf32x"]
+script = ExtResource("5_16m7n")
+name = &"set_var_Bumps"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": 0
+}
+
+[sub_resource type="Resource" id="Resource_ms7k1"]
 script = ExtResource("5_16m7n")
 name = &"ready"
-position = Vector2(50, -100)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_s730d")]]
-block_serialized_properties = SubResource("Resource_4gw1y")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_ojsiq"), SubResource("Resource_yf32x")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_jwr8g"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"method_name": "ResetViewport"
-}]]
+[sub_resource type="Resource" id="Resource_fdsqy"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_ms7k1")
+canvas_position = Vector2(75, 25)
 
-[sub_resource type="Resource" id="Resource_ah3tp"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"text": "Viewport: Resetting!"
-}]]
-
-[sub_resource type="Resource" id="Resource_jw211"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": Vector2(0, 0)
-}]]
-
-[sub_resource type="Resource" id="Resource_mdkmk"]
-script = ExtResource("5_16m7n")
-name = &"Node2D_set_position"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_jw211")
-
-[sub_resource type="Resource" id="Resource_qhb66"]
-script = ExtResource("5_16m7n")
-name = &"print"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mdkmk")]]
-block_serialized_properties = SubResource("Resource_ah3tp")
-
-[sub_resource type="Resource" id="Resource_pl7vb"]
-script = ExtResource("5_16m7n")
-name = &"define_method"
-position = Vector2(50, 50)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_qhb66")]]
-block_serialized_properties = SubResource("Resource_jwr8g")
-
-[sub_resource type="Resource" id="Resource_11jmc"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_b4wrn"]
-script = ExtResource("6_8anhq")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_uwsxe"]
-script = ExtResource("7_ipmj4")
-selected = 5
-items = ["ui_accept", "ui_select", "ui_cancel", "ui_focus_next", "ui_focus_prev", "ui_left", "ui_right", "ui_up", "ui_down", "ui_page_up", "ui_page_down", "ui_home", "ui_end", "ui_cut", "ui_copy", "ui_paste", "ui_undo", "ui_redo", "ui_text_completion_query", "ui_text_completion_accept", "ui_text_completion_replace", "ui_text_newline", "ui_text_newline_blank", "ui_text_newline_above", "ui_text_indent", "ui_text_dedent", "ui_text_backspace", "ui_text_backspace_word", "ui_text_backspace_word.macos", "ui_text_backspace_all_to_left", "ui_text_backspace_all_to_left.macos", "ui_text_delete", "ui_text_delete_word", "ui_text_delete_word.macos", "ui_text_delete_all_to_right", "ui_text_delete_all_to_right.macos", "ui_text_caret_left", "ui_text_caret_word_left", "ui_text_caret_word_left.macos", "ui_text_caret_right", "ui_text_caret_word_right", "ui_text_caret_word_right.macos", "ui_text_caret_up", "ui_text_caret_down", "ui_text_caret_line_start", "ui_text_caret_line_start.macos", "ui_text_caret_line_end", "ui_text_caret_line_end.macos", "ui_text_caret_page_up", "ui_text_caret_page_down", "ui_text_caret_document_start", "ui_text_caret_document_start.macos", "ui_text_caret_document_end", "ui_text_caret_document_end.macos", "ui_text_caret_add_below", "ui_text_caret_add_below.macos", "ui_text_caret_add_above", "ui_text_caret_add_above.macos", "ui_text_scroll_up", "ui_text_scroll_up.macos", "ui_text_scroll_down", "ui_text_scroll_down.macos", "ui_text_select_all", "ui_text_select_word_under_caret", "ui_text_select_word_under_caret.macos", "ui_text_add_selection_for_next_occurrence", "ui_text_skip_selection_for_next_occurrence", "ui_text_clear_carets_and_selection", "ui_text_toggle_insert_mode", "ui_menu", "ui_text_submit", "ui_graph_duplicate", "ui_graph_delete", "ui_filedialog_up_one_level", "ui_filedialog_refresh", "ui_filedialog_show_hidden", "ui_swap_input_direction", "accel", "bump_(pachinko)"]
-
-[sub_resource type="Resource" id="Resource_uoinr"]
-script = ExtResource("7_ipmj4")
-selected = 2
-items = ["pressed", "just_pressed", "just_released"]
-
-[sub_resource type="Resource" id="Resource_6kojo"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"action": SubResource("Resource_uoinr"),
-"action_name": SubResource("Resource_uwsxe")
-}]]
-
-[sub_resource type="Resource" id="Resource_56fk1"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_qteuj"]
+script = ExtResource("9_jnins")
 name = &"is_input_actioned"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_6kojo")
+arguments = {
+"action": "just_released",
+"action_name": &"ui_left"
+}
 
-[sub_resource type="Resource" id="Resource_1wgw1"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_Bumps"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(20, 0)], ["scope", ""], ["block_format", "Set Bumps to {value: INT}"], ["statement", "Bumps = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": null
-}]]
-
-[sub_resource type="Resource" id="Resource_ytxxx"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"a": 1.0,
-"b": 1.0
-}]]
-
-[sub_resource type="Resource" id="Resource_jkc87"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"get_var_Bumps"], ["label", "Param"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "Bumps"], ["statement", "Bumps"], ["defaults", {}], ["variant_type", 2], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_qtxtb"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_l4rk4"]
+script = ExtResource("9_jnins")
 name = &"get_var_Bumps"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_jkc87")
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_84tck"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_qteui"]
+script = ExtResource("9_jnins")
 name = &"add"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_qtxtb")]]
-block_serialized_properties = SubResource("Resource_ytxxx")
+arguments = {
+"a": SubResource("Resource_l4rk4"),
+"b": 1.0
+}
 
-[sub_resource type="Resource" id="Resource_8k8ju"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_tdcob"]
+script = ExtResource("5_16m7n")
+name = &"set_var_Bumps"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": SubResource("Resource_qteui")
+}
+
+[sub_resource type="Resource" id="Resource_kq7cw"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Ball",
 "method_name": "BumpLeft"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_x7jh7"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_ewsv2"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "BumpLabel",
 "method_name": "Bump"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_xtew2"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_veqcu"]
+script = ExtResource("5_16m7n")
+name = &"play_sound"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "db": 0.0,
 "name": "Bump",
 "pitch": 1.0
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_hbkj1"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": Vector2(-5, -1)
-}]]
-
-[sub_resource type="Resource" id="Resource_np5c4"]
+[sub_resource type="Resource" id="Resource_oxe88"]
 script = ExtResource("5_16m7n")
 name = &"Node2D_change_position"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_hbkj1")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": Vector2(-5, -1)
+}
 
-[sub_resource type="Resource" id="Resource_nqlpi"]
+[sub_resource type="Resource" id="Resource_t6i3b"]
 script = ExtResource("5_16m7n")
-name = &"play_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_np5c4")]]
-block_serialized_properties = SubResource("Resource_xtew2")
+name = &"if"
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_tdcob"), SubResource("Resource_kq7cw"), SubResource("Resource_ewsv2"), SubResource("Resource_veqcu"), SubResource("Resource_oxe88")])
+arguments = {
+"condition": SubResource("Resource_qteuj")
+}
 
-[sub_resource type="Resource" id="Resource_54qy1"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_nqlpi")]]
-block_serialized_properties = SubResource("Resource_x7jh7")
+[sub_resource type="Resource" id="Resource_k3trw"]
+script = ExtResource("9_jnins")
+name = &"is_input_actioned"
+arguments = {
+"action": "just_released",
+"action_name": &"ui_right"
+}
 
-[sub_resource type="Resource" id="Resource_6kjo5"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_54qy1")]]
-block_serialized_properties = SubResource("Resource_8k8ju")
+[sub_resource type="Resource" id="Resource_0yuwa"]
+script = ExtResource("9_jnins")
+name = &"get_var_Bumps"
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_14jn2"]
+[sub_resource type="Resource" id="Resource_cqfdy"]
+script = ExtResource("9_jnins")
+name = &"add"
+arguments = {
+"a": SubResource("Resource_0yuwa"),
+"b": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_j8lhd"]
 script = ExtResource("5_16m7n")
 name = &"set_var_Bumps"
-position = Vector2(20, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_84tck")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_6kjo5")]]
-block_serialized_properties = SubResource("Resource_1wgw1")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": SubResource("Resource_cqfdy")
+}
 
-[sub_resource type="Resource" id="Resource_k3nbe"]
-script = ExtResource("6_8anhq")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_n2i7b"]
-script = ExtResource("7_ipmj4")
-selected = 6
-items = ["ui_accept", "ui_select", "ui_cancel", "ui_focus_next", "ui_focus_prev", "ui_left", "ui_right", "ui_up", "ui_down", "ui_page_up", "ui_page_down", "ui_home", "ui_end", "ui_cut", "ui_copy", "ui_paste", "ui_undo", "ui_redo", "ui_text_completion_query", "ui_text_completion_accept", "ui_text_completion_replace", "ui_text_newline", "ui_text_newline_blank", "ui_text_newline_above", "ui_text_indent", "ui_text_dedent", "ui_text_backspace", "ui_text_backspace_word", "ui_text_backspace_word.macos", "ui_text_backspace_all_to_left", "ui_text_backspace_all_to_left.macos", "ui_text_delete", "ui_text_delete_word", "ui_text_delete_word.macos", "ui_text_delete_all_to_right", "ui_text_delete_all_to_right.macos", "ui_text_caret_left", "ui_text_caret_word_left", "ui_text_caret_word_left.macos", "ui_text_caret_right", "ui_text_caret_word_right", "ui_text_caret_word_right.macos", "ui_text_caret_up", "ui_text_caret_down", "ui_text_caret_line_start", "ui_text_caret_line_start.macos", "ui_text_caret_line_end", "ui_text_caret_line_end.macos", "ui_text_caret_page_up", "ui_text_caret_page_down", "ui_text_caret_document_start", "ui_text_caret_document_start.macos", "ui_text_caret_document_end", "ui_text_caret_document_end.macos", "ui_text_caret_add_below", "ui_text_caret_add_below.macos", "ui_text_caret_add_above", "ui_text_caret_add_above.macos", "ui_text_scroll_up", "ui_text_scroll_up.macos", "ui_text_scroll_down", "ui_text_scroll_down.macos", "ui_text_select_all", "ui_text_select_word_under_caret", "ui_text_select_word_under_caret.macos", "ui_text_add_selection_for_next_occurrence", "ui_text_skip_selection_for_next_occurrence", "ui_text_clear_carets_and_selection", "ui_text_toggle_insert_mode", "ui_menu", "ui_text_submit", "ui_graph_duplicate", "ui_graph_delete", "ui_filedialog_up_one_level", "ui_filedialog_refresh", "ui_filedialog_show_hidden", "ui_swap_input_direction", "accel", "bump_(pachinko)"]
-
-[sub_resource type="Resource" id="Resource_dpoli"]
-script = ExtResource("7_ipmj4")
-selected = 2
-items = ["pressed", "just_pressed", "just_released"]
-
-[sub_resource type="Resource" id="Resource_qjnqb"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"action": SubResource("Resource_dpoli"),
-"action_name": SubResource("Resource_n2i7b")
-}]]
-
-[sub_resource type="Resource" id="Resource_1hw0k"]
+[sub_resource type="Resource" id="Resource_g8u6e"]
 script = ExtResource("5_16m7n")
-name = &"is_input_actioned"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_qjnqb")
-
-[sub_resource type="Resource" id="Resource_x2fo7"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_Bumps"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(20, 0)], ["scope", ""], ["block_format", "Set Bumps to {value: INT}"], ["statement", "Bumps = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": null
-}]]
-
-[sub_resource type="Resource" id="Resource_vnmk1"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"a": 1.0,
-"b": 1.0
-}]]
-
-[sub_resource type="Resource" id="Resource_neyxo"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"get_var_Bumps"], ["label", "Param"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "Bumps"], ["statement", "Bumps"], ["defaults", {}], ["variant_type", 2], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_d05vr"]
-script = ExtResource("5_16m7n")
-name = &"get_var_Bumps"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_neyxo")
-
-[sub_resource type="Resource" id="Resource_ssqxp"]
-script = ExtResource("5_16m7n")
-name = &"add"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_d05vr")]]
-block_serialized_properties = SubResource("Resource_vnmk1")
-
-[sub_resource type="Resource" id="Resource_i2jf0"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Ball",
 "method_name": "BumpRight"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_fggk5"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_vu0d1"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "BumpLabel",
 "method_name": "Bump"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_fu3dx"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_sjosp"]
+script = ExtResource("5_16m7n")
+name = &"play_sound"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "db": 0.0,
 "name": "Bump",
 "pitch": 1.0
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_6olgq"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": Vector2(5, -1)
-}]]
-
-[sub_resource type="Resource" id="Resource_anl8a"]
+[sub_resource type="Resource" id="Resource_6p36x"]
 script = ExtResource("5_16m7n")
 name = &"Node2D_change_position"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_6olgq")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": Vector2(5, -1)
+}
 
-[sub_resource type="Resource" id="Resource_0vv4n"]
+[sub_resource type="Resource" id="Resource_rqfgm"]
 script = ExtResource("5_16m7n")
-name = &"play_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_anl8a")]]
-block_serialized_properties = SubResource("Resource_fu3dx")
+name = &"if"
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_j8lhd"), SubResource("Resource_g8u6e"), SubResource("Resource_vu0d1"), SubResource("Resource_sjosp"), SubResource("Resource_6p36x")])
+arguments = {
+"condition": SubResource("Resource_k3trw")
+}
 
-[sub_resource type="Resource" id="Resource_x6sp5"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_0vv4n")]]
-block_serialized_properties = SubResource("Resource_fggk5")
-
-[sub_resource type="Resource" id="Resource_efdqn"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_x6sp5")]]
-block_serialized_properties = SubResource("Resource_i2jf0")
-
-[sub_resource type="Resource" id="Resource_w8yde"]
-script = ExtResource("5_16m7n")
-name = &"set_var_Bumps"
-position = Vector2(20, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_ssqxp")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_efdqn")]]
-block_serialized_properties = SubResource("Resource_x2fo7")
-
-[sub_resource type="Resource" id="Resource_5013w"]
-script = ExtResource("6_8anhq")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_a8fyk"]
-script = ExtResource("7_ipmj4")
-selected = 0
-items = ["ui_accept", "ui_select", "ui_cancel", "ui_focus_next", "ui_focus_prev", "ui_left", "ui_right", "ui_up", "ui_down", "ui_page_up", "ui_page_down", "ui_home", "ui_end", "ui_cut", "ui_copy", "ui_paste", "ui_undo", "ui_redo", "ui_text_completion_query", "ui_text_completion_accept", "ui_text_completion_replace", "ui_text_newline", "ui_text_newline_blank", "ui_text_newline_above", "ui_text_indent", "ui_text_dedent", "ui_text_backspace", "ui_text_backspace_word", "ui_text_backspace_word.macos", "ui_text_backspace_all_to_left", "ui_text_backspace_all_to_left.macos", "ui_text_delete", "ui_text_delete_word", "ui_text_delete_word.macos", "ui_text_delete_all_to_right", "ui_text_delete_all_to_right.macos", "ui_text_caret_left", "ui_text_caret_word_left", "ui_text_caret_word_left.macos", "ui_text_caret_right", "ui_text_caret_word_right", "ui_text_caret_word_right.macos", "ui_text_caret_up", "ui_text_caret_down", "ui_text_caret_line_start", "ui_text_caret_line_start.macos", "ui_text_caret_line_end", "ui_text_caret_line_end.macos", "ui_text_caret_page_up", "ui_text_caret_page_down", "ui_text_caret_document_start", "ui_text_caret_document_start.macos", "ui_text_caret_document_end", "ui_text_caret_document_end.macos", "ui_text_caret_add_below", "ui_text_caret_add_below.macos", "ui_text_caret_add_above", "ui_text_caret_add_above.macos", "ui_text_scroll_up", "ui_text_scroll_up.macos", "ui_text_scroll_down", "ui_text_scroll_down.macos", "ui_text_select_all", "ui_text_select_word_under_caret", "ui_text_select_word_under_caret.macos", "ui_text_add_selection_for_next_occurrence", "ui_text_skip_selection_for_next_occurrence", "ui_text_clear_carets_and_selection", "ui_text_toggle_insert_mode", "ui_menu", "ui_text_submit", "ui_graph_duplicate", "ui_graph_delete", "ui_filedialog_up_one_level", "ui_filedialog_refresh", "ui_filedialog_show_hidden", "ui_swap_input_direction", "accel", "bump_(pachinko)"]
-
-[sub_resource type="Resource" id="Resource_gelyp"]
-script = ExtResource("7_ipmj4")
-selected = 2
-items = ["pressed", "just_pressed", "just_released"]
-
-[sub_resource type="Resource" id="Resource_qlvhj"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"action": SubResource("Resource_gelyp"),
-"action_name": SubResource("Resource_a8fyk")
-}]]
-
-[sub_resource type="Resource" id="Resource_rttgs"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_esdf0"]
+script = ExtResource("9_jnins")
 name = &"is_input_actioned"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_qlvhj")
+arguments = {
+"action": "just_released",
+"action_name": &"ui_accept"
+}
 
-[sub_resource type="Resource" id="Resource_hcv0a"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_yys0s"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Viewport",
 "method_name": "ResetViewport"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_sr147"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_tnwyk"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Ball",
 "method_name": "Reset"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_1sh48"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_Bumps"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "Set Bumps to {value: INT}"], ["statement", "Bumps = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": 0
-}]]
-
-[sub_resource type="Resource" id="Resource_1e1vg"]
+[sub_resource type="Resource" id="Resource_23st5"]
 script = ExtResource("5_16m7n")
 name = &"set_var_Bumps"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_1sh48")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": 0
+}
 
-[sub_resource type="Resource" id="Resource_ahwwg"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_1e1vg")]]
-block_serialized_properties = SubResource("Resource_sr147")
-
-[sub_resource type="Resource" id="Resource_t63j8"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(20, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ahwwg")]]
-block_serialized_properties = SubResource("Resource_hcv0a")
-
-[sub_resource type="Resource" id="Resource_55bhu"]
+[sub_resource type="Resource" id="Resource_m542x"]
 script = ExtResource("5_16m7n")
 name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_rttgs")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_t63j8")]]
-block_serialized_properties = SubResource("Resource_5013w")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_yys0s"), SubResource("Resource_tnwyk"), SubResource("Resource_23st5")])
+arguments = {
+"condition": SubResource("Resource_esdf0")
+}
 
-[sub_resource type="Resource" id="Resource_2ytf5"]
-script = ExtResource("5_16m7n")
-name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_1hw0k")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_w8yde")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_55bhu")]]
-block_serialized_properties = SubResource("Resource_k3nbe")
-
-[sub_resource type="Resource" id="Resource_tmrnf"]
-script = ExtResource("5_16m7n")
-name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_56fk1")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_14jn2")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_2ytf5")]]
-block_serialized_properties = SubResource("Resource_b4wrn")
-
-[sub_resource type="Resource" id="Resource_rjodi"]
+[sub_resource type="Resource" id="Resource_xbdpv"]
 script = ExtResource("5_16m7n")
 name = &"process"
-position = Vector2(50, 200)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_tmrnf")]]
-block_serialized_properties = SubResource("Resource_11jmc")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_t6i3b"), SubResource("Resource_rqfgm"), SubResource("Resource_m542x")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_864rf"]
-script = ExtResource("9_rblu1")
+[sub_resource type="Resource" id="Resource_xebb8"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_xbdpv")
+canvas_position = Vector2(1100, 25)
+
+[sub_resource type="Resource" id="Resource_c5yuk"]
+script = ExtResource("5_16m7n")
+name = &"print"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"text": "Viewport: Resetting!"
+}
+
+[sub_resource type="Resource" id="Resource_n24hy"]
+script = ExtResource("5_16m7n")
+name = &"Node2D_set_position"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": Vector2(0, 0)
+}
+
+[sub_resource type="Resource" id="Resource_blgoe"]
+script = ExtResource("9_jnins")
+name = &"get_node"
+arguments = {
+"path": NodePath("BumpLabel")
+}
+
+[sub_resource type="Resource" id="Resource_wa3nc"]
+script = ExtResource("5_16m7n")
+name = &"call_method_node"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"method_name": "Reset",
+"node": SubResource("Resource_blgoe")
+}
+
+[sub_resource type="Resource" id="Resource_injhk"]
+script = ExtResource("5_16m7n")
+name = &"define_method"
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_c5yuk"), SubResource("Resource_n24hy"), SubResource("Resource_wa3nc")])
+arguments = {
+"method_name": &"ResetViewport"
+}
+
+[sub_resource type="Resource" id="Resource_vjxb0"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_injhk")
+canvas_position = Vector2(75, 275)
+
+[sub_resource type="Resource" id="Resource_hh2ic"]
+script = ExtResource("4_oqjhm")
 var_name = "Bumps"
 var_type = 2
 
 [sub_resource type="Resource" id="Resource_n6gnx"]
 script = ExtResource("8_wkl7e")
 script_inherits = "Node2D"
-block_trees = Array[ExtResource("5_16m7n")]([SubResource("Resource_acsgj"), SubResource("Resource_pl7vb"), SubResource("Resource_rjodi")])
-variables = Array[ExtResource("9_rblu1")]([SubResource("Resource_864rf")])
+block_serialization_trees = Array[ExtResource("2_cvyqc")]([SubResource("Resource_fdsqy"), SubResource("Resource_xebb8"), SubResource("Resource_vjxb0")])
+variables = Array[ExtResource("4_oqjhm")]([SubResource("Resource_hh2ic")])
 generated_script = "extends Node2D
 
 var Bumps: int
@@ -489,163 +303,115 @@ func _ready():
 	__sound_1.name = 'Bump'
 	__sound_1.set_stream(load('res://game-04/Sounds/Bump.ogg'))
 	add_child(__sound_1)
+
 	Bumps = 0
 
-func ResetViewport():
-	print('Viewport: Resetting!')
-	position = Vector2(0, 0)
-
 func _process(delta):
-	if Input.is_action_just_released(\"ui_left\"):
-		Bumps = int(float(Bumps) + 1)
+	if (Input.is_action_just_released('ui_left')):
+		Bumps = ((Bumps) + 1)
 		get_tree().call_group('Ball', 'BumpLeft')
 		get_tree().call_group('BumpLabel', 'Bump')
 		var __sound_node_1 = get_node('Bump')
 		__sound_node_1.volume_db = 0
 		__sound_node_1.pitch_scale = 1
 		__sound_node_1.play()
+
 		position += Vector2(-5, -1)
-	if Input.is_action_just_released(\"ui_right\"):
-		Bumps = int(float(Bumps) + 1)
+	if (Input.is_action_just_released('ui_right')):
+		Bumps = ((Bumps) + 1)
 		get_tree().call_group('Ball', 'BumpRight')
 		get_tree().call_group('BumpLabel', 'Bump')
 		var __sound_node_2 = get_node('Bump')
 		__sound_node_2.volume_db = 0
 		__sound_node_2.pitch_scale = 1
 		__sound_node_2.play()
+
 		position += Vector2(5, -1)
-	if Input.is_action_just_released(\"ui_accept\"):
+	if (Input.is_action_just_released('ui_accept')):
 		get_tree().call_group('Viewport', 'ResetViewport')
 		get_tree().call_group('Ball', 'Reset')
 		Bumps = 0
 
+func ResetViewport():
+	print('Viewport: Resetting!')
+	position = Vector2(0, 0)
+	(get_node(\"BumpLabel\")).call('Reset')
+
 "
 version = 0
 
-[sub_resource type="Resource" id="Resource_sp4t8"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_lkpl6"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"file_path": "res://game-04/Sounds/Wood 3.ogg",
-"name": "Wall"
-}]]
-
-[sub_resource type="Resource" id="Resource_meapu"]
+[sub_resource type="Resource" id="Resource_v81dy"]
 script = ExtResource("5_16m7n")
 name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_lkpl6")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"file_path": "res://game-04/Sounds/Wood 3.ogg",
+"name": "Wall"
+}
 
-[sub_resource type="Resource" id="Resource_sd2o2"]
+[sub_resource type="Resource" id="Resource_dxkf3"]
 script = ExtResource("5_16m7n")
 name = &"ready"
-position = Vector2(50, 50)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_meapu")]]
-block_serialized_properties = SubResource("Resource_sp4t8")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_v81dy")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_lpauq"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
+[sub_resource type="Resource" id="Resource_u5ktd"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_dxkf3")
+canvas_position = Vector2(25, 0)
 
-[sub_resource type="Resource" id="Resource_oss1g"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
+[sub_resource type="Resource" id="Resource_c4bwj"]
+script = ExtResource("9_jnins")
+name = &"area2d_on_entered:something"
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_tjg41"]
-script = ExtResource("5_16m7n")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_oss1g")
-
-[sub_resource type="Resource" id="Resource_plxab"]
-script = ExtResource("6_8anhq")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_si3vk"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"group": "Ball",
-"node": ""
-}]]
-
-[sub_resource type="Resource" id="Resource_bekoh"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_143y5"]
-script = ExtResource("5_16m7n")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_bekoh")
-
-[sub_resource type="Resource" id="Resource_fgsbn"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_3qyn4"]
+script = ExtResource("9_jnins")
 name = &"is_node_in_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_143y5")]]
-block_serialized_properties = SubResource("Resource_si3vk")
+arguments = {
+"group": "Ball",
+"node": SubResource("Resource_c4bwj")
+}
 
-[sub_resource type="Resource" id="Resource_cdqvc"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_kfh0h"]
+script = ExtResource("5_16m7n")
+name = &"play_sound"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "db": 0.0,
 "name": "Wall",
 "pitch": 1.0
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_qvi0r"]
-script = ExtResource("5_16m7n")
-name = &"play_sound"
-position = Vector2(20, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_cdqvc")
-
-[sub_resource type="Resource" id="Resource_qcbad"]
+[sub_resource type="Resource" id="Resource_xgnfn"]
 script = ExtResource("5_16m7n")
 name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_fgsbn")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_qvi0r")]]
-block_serialized_properties = SubResource("Resource_plxab")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_kfh0h")])
+arguments = {
+"condition": SubResource("Resource_3qyn4")
+}
 
-[sub_resource type="Resource" id="Resource_ttuuu"]
+[sub_resource type="Resource" id="Resource_bwnnd"]
 script = ExtResource("5_16m7n")
 name = &"area2d_on_entered"
-position = Vector2(50, 175)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterOutput0/SnapPoint"), SubResource("Resource_tjg41")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_qcbad")]]
-block_serialized_properties = SubResource("Resource_lpauq")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_xgnfn")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_jqbno"]
-script = ExtResource("9_rblu1")
-var_name = "HitSound"
-var_type = 2
+[sub_resource type="Resource" id="Resource_dt1iu"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_bwnnd")
+canvas_position = Vector2(50, 200)
 
 [sub_resource type="Resource" id="Resource_piq6x"]
 script = ExtResource("8_wkl7e")
 script_inherits = "Area2D"
-block_trees = Array[ExtResource("5_16m7n")]([SubResource("Resource_sd2o2"), SubResource("Resource_ttuuu")])
-variables = Array[ExtResource("9_rblu1")]([SubResource("Resource_jqbno")])
+block_serialization_trees = Array[ExtResource("2_cvyqc")]([SubResource("Resource_u5ktd"), SubResource("Resource_dt1iu")])
+variables = Array[ExtResource("4_oqjhm")]([])
 generated_script = "extends Area2D
 
-var HitSound: int
 
+func _init():
+	body_entered.connect(_on_body_entered)
 
 func _ready():
 	var __sound_1 = AudioStreamPlayer.new()
@@ -653,16 +419,16 @@ func _ready():
 	__sound_1.set_stream(load('res://game-04/Sounds/Wood 3.ogg'))
 	add_child(__sound_1)
 
-func _on_body_entered(body: Node2D):
 
-	if body.is_in_group('Ball'):
+func _on_body_entered(something: Node2D):
+
+	if ((something).is_in_group('Ball')):
 		var __sound_node_1 = get_node('Wall')
 		__sound_node_1.volume_db = 0
 		__sound_node_1.pitch_scale = 1
 		__sound_node_1.play()
 
-func _init():
-	body_entered.connect(_on_body_entered)
+
 "
 version = 0
 
@@ -684,365 +450,228 @@ distance = -720.0
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_mgdhw"]
 size = Vector2(120, 30)
 
-[sub_resource type="Resource" id="Resource_7rnxy"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
+[sub_resource type="Resource" id="Resource_poyd5"]
+script = ExtResource("9_jnins")
+name = &"area2d_on_entered:something"
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_hlww5"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_e3d4l"]
-script = ExtResource("5_16m7n")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_hlww5")
-
-[sub_resource type="Resource" id="Resource_5tlc2"]
-script = ExtResource("6_8anhq")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_chtpx"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"group": "Ball",
-"node": ""
-}]]
-
-[sub_resource type="Resource" id="Resource_bq0li"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_afsj2"]
-script = ExtResource("5_16m7n")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_bq0li")
-
-[sub_resource type="Resource" id="Resource_fcn80"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_xkrj3"]
+script = ExtResource("9_jnins")
 name = &"is_node_in_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_afsj2")]]
-block_serialized_properties = SubResource("Resource_chtpx")
+arguments = {
+"group": "Ball",
+"node": SubResource("Resource_poyd5")
+}
 
-[sub_resource type="Resource" id="Resource_qfw1i"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_pbb7w"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Ball",
 "method_name": "Reset"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_hddqd"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_7md8r"]
+script = ExtResource("5_16m7n")
+name = &"call_method_group"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "group": "Viewport",
 "method_name": "ResetViewport"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_0jok1"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_hddqd")
-
-[sub_resource type="Resource" id="Resource_dsbid"]
-script = ExtResource("5_16m7n")
-name = &"call_method_group"
-position = Vector2(20, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_0jok1")]]
-block_serialized_properties = SubResource("Resource_qfw1i")
-
-[sub_resource type="Resource" id="Resource_rr7hv"]
+[sub_resource type="Resource" id="Resource_gq8h6"]
 script = ExtResource("5_16m7n")
 name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_fcn80")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_dsbid")]]
-block_serialized_properties = SubResource("Resource_5tlc2")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_pbb7w"), SubResource("Resource_7md8r")])
+arguments = {
+"condition": SubResource("Resource_xkrj3")
+}
 
-[sub_resource type="Resource" id="Resource_l7cq5"]
+[sub_resource type="Resource" id="Resource_jhwdc"]
 script = ExtResource("5_16m7n")
 name = &"area2d_on_entered"
-position = Vector2(75, 75)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterOutput0/SnapPoint"), SubResource("Resource_e3d4l")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_rr7hv")]]
-block_serialized_properties = SubResource("Resource_7rnxy")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_gq8h6")])
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_rrfqc"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_jhwdc")
+canvas_position = Vector2(175, 75)
 
 [sub_resource type="Resource" id="Resource_crxoy"]
 script = ExtResource("8_wkl7e")
 script_inherits = "Area2D"
-block_trees = Array[ExtResource("5_16m7n")]([SubResource("Resource_l7cq5")])
-variables = Array[ExtResource("9_rblu1")]([])
+block_serialization_trees = Array[ExtResource("2_cvyqc")]([SubResource("Resource_rrfqc")])
+variables = Array[ExtResource("4_oqjhm")]([])
 generated_script = "extends Area2D
 
 
-func _on_body_entered(body: Node2D):
+func _init():
+	body_entered.connect(_on_body_entered)
 
-	if body.is_in_group('Ball'):
+func _on_body_entered(something: Node2D):
+
+	if ((something).is_in_group('Ball')):
 		get_tree().call_group('Ball', 'Reset')
 		get_tree().call_group('Viewport', 'ResetViewport')
 
-func _init():
-	body_entered.connect(_on_body_entered)
 "
 version = 0
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_m4fpc"]
 distance = -540.0
 
-[sub_resource type="Resource" id="Resource_8iyb2"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"method_name": "Reset"
-}]]
-
-[sub_resource type="Resource" id="Resource_37ttn"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_q7s8h"]
+script = ExtResource("5_16m7n")
+name = &"print"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "text": "Ball: Resetting!"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_pcnxl"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"position": Vector2(480, 0)
-}]]
-
-[sub_resource type="Resource" id="Resource_7gb12"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"x": null,
-"y": 0.0
-}]]
-
-[sub_resource type="Resource" id="Resource_lmua5"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_4f140"]
+script = ExtResource("9_jnins")
+name = &"randi_range"
+arguments = {
 "from": 270,
 "to": 690
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_8nosn"]
-script = ExtResource("5_16m7n")
-name = &"randi_range"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_lmua5")
-
-[sub_resource type="Resource" id="Resource_p8qek"]
-script = ExtResource("5_16m7n")
+[sub_resource type="Resource" id="Resource_h1hlh"]
+script = ExtResource("9_jnins")
 name = &"vector2"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_8nosn")]]
-block_serialized_properties = SubResource("Resource_7gb12")
+arguments = {
+"x": SubResource("Resource_4f140"),
+"y": 0.0
+}
 
-[sub_resource type="Resource" id="Resource_yk6r6"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": Vector2(0, 0)
-}]]
-
-[sub_resource type="Resource" id="Resource_h4rx3"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": 0.0
-}]]
-
-[sub_resource type="Resource" id="Resource_3xmpk"]
-script = ExtResource("6_8anhq")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"from": -1.0,
-"to": 1.0
-}]]
-
-[sub_resource type="Resource" id="Resource_fyk3j"]
-script = ExtResource("5_16m7n")
-name = &"randf_range"
-position = Vector2(-122, -20)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_3xmpk")
-
-[sub_resource type="Resource" id="Resource_torhd"]
-script = ExtResource("5_16m7n")
-name = &"RigidBody2D_set_angular_velocity"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_fyk3j")]]
-block_serialized_properties = SubResource("Resource_h4rx3")
-
-[sub_resource type="Resource" id="Resource_hsolc"]
-script = ExtResource("5_16m7n")
-name = &"RigidBody2D_set_linear_velocity"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_torhd")]]
-block_serialized_properties = SubResource("Resource_yk6r6")
-
-[sub_resource type="Resource" id="Resource_e03dn"]
+[sub_resource type="Resource" id="Resource_w8jv5"]
 script = ExtResource("5_16m7n")
 name = &"rigidbody2d_physics_position"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_p8qek")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_hsolc")]]
-block_serialized_properties = SubResource("Resource_pcnxl")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"position": SubResource("Resource_h1hlh")
+}
 
-[sub_resource type="Resource" id="Resource_qrqu0"]
+[sub_resource type="Resource" id="Resource_hqscq"]
 script = ExtResource("5_16m7n")
-name = &"print"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_e03dn")]]
-block_serialized_properties = SubResource("Resource_37ttn")
+name = &"RigidBody2D_set_linear_velocity"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": Vector2(0, 0)
+}
 
-[sub_resource type="Resource" id="Resource_acoej"]
+[sub_resource type="Resource" id="Resource_72etc"]
+script = ExtResource("9_jnins")
+name = &"randf_range"
+arguments = {
+"from": -1.0,
+"to": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_qb66a"]
+script = ExtResource("5_16m7n")
+name = &"RigidBody2D_set_angular_velocity"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": SubResource("Resource_72etc")
+}
+
+[sub_resource type="Resource" id="Resource_pfjr6"]
 script = ExtResource("5_16m7n")
 name = &"define_method"
-position = Vector2(-25, -25)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_qrqu0")]]
-block_serialized_properties = SubResource("Resource_8iyb2")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_q7s8h"), SubResource("Resource_w8jv5"), SubResource("Resource_hqscq"), SubResource("Resource_qb66a")])
+arguments = {
+"method_name": &"Reset"
+}
 
-[sub_resource type="Resource" id="Resource_exhpq"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"method_name": "BumpLeft"
-}]]
+[sub_resource type="Resource" id="Resource_xu7n2"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_pfjr6")
+canvas_position = Vector2(25, 0)
 
-[sub_resource type="Resource" id="Resource_xt6n2"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_tugfl"]
+script = ExtResource("5_16m7n")
+name = &"print"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "text": "Ball: Bump left!"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_6uqky"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_us4rf"]
+script = ExtResource("5_16m7n")
+name = &"RigidBody2D_change_linear_velocity"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "value": Vector2(-300, -100)
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_kmnqj"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_hcjw6"]
+script = ExtResource("5_16m7n")
+name = &"RigidBody2D_change_angular_velocity"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "value": -1.0
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_dwhu2"]
-script = ExtResource("5_16m7n")
-name = &"RigidBody2D_change_angular_velocity"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_kmnqj")
-
-[sub_resource type="Resource" id="Resource_6qh0w"]
-script = ExtResource("5_16m7n")
-name = &"RigidBody2D_change_linear_velocity"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_dwhu2")]]
-block_serialized_properties = SubResource("Resource_6uqky")
-
-[sub_resource type="Resource" id="Resource_dgbwg"]
-script = ExtResource("5_16m7n")
-name = &"print"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_6qh0w")]]
-block_serialized_properties = SubResource("Resource_xt6n2")
-
-[sub_resource type="Resource" id="Resource_702d7"]
+[sub_resource type="Resource" id="Resource_v74bg"]
 script = ExtResource("5_16m7n")
 name = &"define_method"
-position = Vector2(-25, 250)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_dgbwg")]]
-block_serialized_properties = SubResource("Resource_exhpq")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_tugfl"), SubResource("Resource_us4rf"), SubResource("Resource_hcjw6")])
+arguments = {
+"method_name": &"BumpLeft"
+}
 
-[sub_resource type="Resource" id="Resource_6qv0r"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"method_name": "BumpRight"
-}]]
+[sub_resource type="Resource" id="Resource_eybxl"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_v74bg")
+canvas_position = Vector2(50, 500)
 
-[sub_resource type="Resource" id="Resource_8dob1"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_r2ci8"]
+script = ExtResource("5_16m7n")
+name = &"print"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
 "text": "Ball: Bump right!"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_ceyk6"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": Vector2(300, -100)
-}]]
-
-[sub_resource type="Resource" id="Resource_mu0q0"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": 1.0
-}]]
-
-[sub_resource type="Resource" id="Resource_nkt25"]
-script = ExtResource("5_16m7n")
-name = &"RigidBody2D_change_angular_velocity"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_mu0q0")
-
-[sub_resource type="Resource" id="Resource_4av2m"]
+[sub_resource type="Resource" id="Resource_ofdes"]
 script = ExtResource("5_16m7n")
 name = &"RigidBody2D_change_linear_velocity"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_nkt25")]]
-block_serialized_properties = SubResource("Resource_ceyk6")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": Vector2(300, -100)
+}
 
-[sub_resource type="Resource" id="Resource_kk4n0"]
+[sub_resource type="Resource" id="Resource_wthl3"]
 script = ExtResource("5_16m7n")
-name = &"print"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_4av2m")]]
-block_serialized_properties = SubResource("Resource_8dob1")
+name = &"RigidBody2D_change_angular_velocity"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": 1.0
+}
 
-[sub_resource type="Resource" id="Resource_xy646"]
+[sub_resource type="Resource" id="Resource_dc6ir"]
 script = ExtResource("5_16m7n")
 name = &"define_method"
-position = Vector2(-25, 450)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_kk4n0")]]
-block_serialized_properties = SubResource("Resource_6qv0r")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_r2ci8"), SubResource("Resource_ofdes"), SubResource("Resource_wthl3")])
+arguments = {
+"method_name": &"BumpRight"
+}
 
-[sub_resource type="Resource" id="Resource_uxjpn"]
-script = ExtResource("9_rblu1")
-var_name = "BallDropped"
-var_type = 1
+[sub_resource type="Resource" id="Resource_4x8o3"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_dc6ir")
+canvas_position = Vector2(650, 500)
 
 [sub_resource type="Resource" id="Resource_f2fav"]
 script = ExtResource("8_wkl7e")
 script_inherits = "RigidBody2D"
-block_trees = Array[ExtResource("5_16m7n")]([SubResource("Resource_acoej"), SubResource("Resource_702d7"), SubResource("Resource_xy646")])
-variables = Array[ExtResource("9_rblu1")]([SubResource("Resource_uxjpn")])
+block_serialization_trees = Array[ExtResource("2_cvyqc")]([SubResource("Resource_xu7n2"), SubResource("Resource_eybxl"), SubResource("Resource_4x8o3")])
+variables = Array[ExtResource("4_oqjhm")]([])
 generated_script = "extends RigidBody2D
-
-var BallDropped: bool
 
 
 func Reset():
@@ -1050,10 +679,11 @@ func Reset():
 	PhysicsServer2D.body_set_state(
 		get_rid(),
 		PhysicsServer2D.BODY_STATE_TRANSFORM,
-		Transform2D.IDENTITY.translated(Vector2(float(randi_range(270, 690)), 0))
+		Transform2D.IDENTITY.translated((Vector2((randi_range(270, 690)), 0)))
 	)
+
 	linear_velocity = Vector2(0, 0)
-	angular_velocity = randf_range(-1, 1)
+	angular_velocity = (randf_range(-1, 1))
 
 func BumpLeft():
 	print('Ball: Bump left!')
@@ -1068,101 +698,73 @@ func BumpRight():
 "
 version = 0
 
-[sub_resource type="Resource" id="Resource_sd347"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_7yn1v"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": false
-}]]
-
-[sub_resource type="Resource" id="Resource_3piml"]
+[sub_resource type="Resource" id="Resource_2ke5p"]
 script = ExtResource("5_16m7n")
 name = &"CanvasItem_set_visible"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_7yn1v")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": false
+}
 
-[sub_resource type="Resource" id="Resource_sb1wd"]
+[sub_resource type="Resource" id="Resource_c28rb"]
 script = ExtResource("5_16m7n")
 name = &"ready"
-position = Vector2(-25, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_3piml")]]
-block_serialized_properties = SubResource("Resource_sd347")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_2ke5p")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_dkqb0"]
-script = ExtResource("6_8anhq")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"method_name": "Bump"
-}]]
+[sub_resource type="Resource" id="Resource_aia1a"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_c28rb")
+canvas_position = Vector2(0, 50)
 
-[sub_resource type="Resource" id="Resource_elop8"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"value": true
-}]]
-
-[sub_resource type="Resource" id="Resource_2hrxf"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"text": "BumpLabel: Bump!"
-}]]
-
-[sub_resource type="Resource" id="Resource_f8n2t"]
-script = ExtResource("6_8anhq")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_FrameCount"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "Set FrameCount to {value: INT}"], ["statement", "FrameCount = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": 0
-}]]
-
-[sub_resource type="Resource" id="Resource_x03te"]
-script = ExtResource("5_16m7n")
-name = &"set_var_FrameCount"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_f8n2t")
-
-[sub_resource type="Resource" id="Resource_fe3h8"]
-script = ExtResource("5_16m7n")
-name = &"print"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_x03te")]]
-block_serialized_properties = SubResource("Resource_2hrxf")
-
-[sub_resource type="Resource" id="Resource_u8fwb"]
+[sub_resource type="Resource" id="Resource_t6ekn"]
 script = ExtResource("5_16m7n")
 name = &"CanvasItem_set_visible"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_fe3h8")]]
-block_serialized_properties = SubResource("Resource_elop8")
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": true
+}
 
-[sub_resource type="Resource" id="Resource_yjd2a"]
+[sub_resource type="Resource" id="Resource_fycgf"]
 script = ExtResource("5_16m7n")
 name = &"define_method"
-position = Vector2(-25, 150)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_u8fwb")]]
-block_serialized_properties = SubResource("Resource_dkqb0")
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_t6ekn")])
+arguments = {
+"method_name": &"Bump"
+}
 
-[sub_resource type="Resource" id="Resource_ghng7"]
-script = ExtResource("9_rblu1")
-var_name = "FrameCount"
-var_type = 2
+[sub_resource type="Resource" id="Resource_yaldx"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_fycgf")
+canvas_position = Vector2(0, 225)
+
+[sub_resource type="Resource" id="Resource_1nvem"]
+script = ExtResource("5_16m7n")
+name = &"CanvasItem_set_visible"
+children = Array[ExtResource("5_16m7n")]([])
+arguments = {
+"value": false
+}
+
+[sub_resource type="Resource" id="Resource_7ieqn"]
+script = ExtResource("5_16m7n")
+name = &"define_method"
+children = Array[ExtResource("5_16m7n")]([SubResource("Resource_1nvem")])
+arguments = {
+"method_name": &"Reset"
+}
+
+[sub_resource type="Resource" id="Resource_nocve"]
+script = ExtResource("2_cvyqc")
+root = SubResource("Resource_7ieqn")
+canvas_position = Vector2(50, 400)
 
 [sub_resource type="Resource" id="Resource_dd2h5"]
 script = ExtResource("8_wkl7e")
 script_inherits = "Label"
-block_trees = Array[ExtResource("5_16m7n")]([SubResource("Resource_sb1wd"), SubResource("Resource_yjd2a")])
-variables = Array[ExtResource("9_rblu1")]([SubResource("Resource_ghng7")])
+block_serialization_trees = Array[ExtResource("2_cvyqc")]([SubResource("Resource_aia1a"), SubResource("Resource_yaldx"), SubResource("Resource_nocve")])
+variables = Array[ExtResource("4_oqjhm")]([])
 generated_script = "extends Label
-
-var FrameCount: int
 
 
 func _ready():
@@ -1170,8 +772,9 @@ func _ready():
 
 func Bump():
 	visible = true
-	print('BumpLabel: Bump!')
-	FrameCount = 0
+
+func Reset():
+	visible = false
 
 "
 version = 0

--- a/game-04/pin.tscn
+++ b/game-04/pin.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=41 format=3 uid="uid://q8ko63dmnn0r"]
+[gd_scene load_steps=44 format=3 uid="uid://q8ko63dmnn0r"]
 
 [ext_resource type="Texture2D" uid="uid://dv2q1pcf3cuek" path="res://game-04/Images/pin.svg" id="1_krluw"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="2_24vdh"]
+[ext_resource type="Script" path="res://addons/block_code/serialization/block_serialization_tree.gd" id="3_arw1h"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_serialization.gd" id="3_vuinq"]
-[ext_resource type="Script" path="res://addons/block_code/serialization/block_serialized_properties.gd" id="4_moeft"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_script_serialization.gd" id="5_3jwsj"]
-[ext_resource type="Script" path="res://addons/block_code/ui/block_canvas/variable_resource.gd" id="6_0s6jk"]
+[ext_resource type="Script" path="res://addons/block_code/serialization/value_block_serialization.gd" id="5_x7mnm"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/variable_definition.gd" id="7_gyajk"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_v1gnx"]
 radius = 15.0
@@ -13,265 +14,334 @@ radius = 15.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_mckva"]
 radius = 15.0
 
-[sub_resource type="Resource" id="Resource_b0aen"]
-script = ExtResource("4_moeft")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_n7tli"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_fvojb"]
+script = ExtResource("3_vuinq")
+name = &"load_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
 "file_path": "res://game-04/Sounds/Muted 1.ogg",
 "name": "1"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_asrws"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_6rtyn"]
+script = ExtResource("3_vuinq")
+name = &"load_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
 "file_path": "res://game-04/Sounds/Muted 2.ogg",
 "name": "2"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_4jpac"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_wredu"]
+script = ExtResource("3_vuinq")
+name = &"load_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
 "file_path": "res://game-04/Sounds/Muted 3.ogg",
 "name": "3"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_82i1t"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_05fc8"]
+script = ExtResource("3_vuinq")
+name = &"load_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
 "file_path": "res://game-04/Sounds/Muted 4.ogg",
 "name": "4"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_7jp3i"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_ldgce"]
+script = ExtResource("3_vuinq")
+name = &"load_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
 "file_path": "res://game-04/Sounds/Muted 5.ogg",
 "name": "5"
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_43mgf"]
-script = ExtResource("3_vuinq")
-name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_7jp3i")
-
-[sub_resource type="Resource" id="Resource_el3f7"]
-script = ExtResource("3_vuinq")
-name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_43mgf")]]
-block_serialized_properties = SubResource("Resource_82i1t")
-
-[sub_resource type="Resource" id="Resource_cn5e5"]
-script = ExtResource("3_vuinq")
-name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_el3f7")]]
-block_serialized_properties = SubResource("Resource_4jpac")
-
-[sub_resource type="Resource" id="Resource_nds5c"]
-script = ExtResource("3_vuinq")
-name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_cn5e5")]]
-block_serialized_properties = SubResource("Resource_asrws")
-
-[sub_resource type="Resource" id="Resource_p33ki"]
-script = ExtResource("3_vuinq")
-name = &"load_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_nds5c")]]
-block_serialized_properties = SubResource("Resource_n7tli")
-
-[sub_resource type="Resource" id="Resource_1h6wi"]
+[sub_resource type="Resource" id="Resource_7vlu6"]
 script = ExtResource("3_vuinq")
 name = &"ready"
-position = Vector2(54, 47)
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_p33ki")]]
-block_serialized_properties = SubResource("Resource_b0aen")
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_fvojb"), SubResource("Resource_6rtyn"), SubResource("Resource_wredu"), SubResource("Resource_05fc8"), SubResource("Resource_ldgce")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_c6g8w"]
-script = ExtResource("4_moeft")
-block_class = &"EntryBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {}]]
+[sub_resource type="Resource" id="Resource_cqan1"]
+script = ExtResource("3_arw1h")
+root = SubResource("Resource_7vlu6")
+canvas_position = Vector2(54, 47)
 
-[sub_resource type="Resource" id="Resource_vs5ea"]
-script = ExtResource("4_moeft")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
+[sub_resource type="Resource" id="Resource_s8wj6"]
+script = ExtResource("5_x7mnm")
+name = &"area2d_on_entered:something"
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_1mt8y"]
-script = ExtResource("3_vuinq")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_vs5ea")
-
-[sub_resource type="Resource" id="Resource_y65b0"]
-script = ExtResource("4_moeft")
-block_class = &"ControlBlock"
-serialized_props = [["scope", ""], ["param_input_strings_array", [{
-"condition": false
-}]]]
-
-[sub_resource type="Resource" id="Resource_krtvt"]
-script = ExtResource("4_moeft")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"group": "Ball",
-"node": ""
-}]]
-
-[sub_resource type="Resource" id="Resource_cgxal"]
-script = ExtResource("4_moeft")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"parameter_block"], ["label", "Param"], ["color", Color(0.294118, 0.482353, 0.92549, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", "func _on_body_entered(body: Node2D):
-"], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 24], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_ms3wr"]
-script = ExtResource("3_vuinq")
-name = &"parameter_block"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_cgxal")
-
-[sub_resource type="Resource" id="Resource_cg7n0"]
-script = ExtResource("3_vuinq")
+[sub_resource type="Resource" id="Resource_gogqm"]
+script = ExtResource("5_x7mnm")
 name = &"is_node_in_group"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_ms3wr")]]
-block_serialized_properties = SubResource("Resource_krtvt")
+arguments = {
+"group": "Ball",
+"node": SubResource("Resource_s8wj6")
+}
 
-[sub_resource type="Resource" id="Resource_fi5gb"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["block_name", &"set_var_PinSound"], ["label", "StatementBlock"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 2], ["position", Vector2(20, 0)], ["scope", ""], ["block_format", "Set PinSound to {value: INT}"], ["statement", "PinSound = {value}"], ["defaults", {}], ["param_input_strings", {
-"value": null
-}]]
-
-[sub_resource type="Resource" id="Resource_2fydv"]
-script = ExtResource("4_moeft")
-block_class = &"ParameterBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
+[sub_resource type="Resource" id="Resource_qfehw"]
+script = ExtResource("5_x7mnm")
+name = &"randi_range"
+arguments = {
 "from": 1,
 "to": 5
-}]]
+}
 
-[sub_resource type="Resource" id="Resource_8jrgs"]
-script = ExtResource("3_vuinq")
-name = &"randi_range"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_2fydv")
-
-[sub_resource type="Resource" id="Resource_ohsst"]
-script = ExtResource("4_moeft")
-block_class = &"StatementBlock"
-serialized_props = [["scope", ""], ["param_input_strings", {
-"db": 0.0,
-"name": "",
-"pitch": 1.0
-}]]
-
-[sub_resource type="Resource" id="Resource_sssdn"]
-script = ExtResource("4_moeft")
-block_class = &"ParameterBlock"
-serialized_props = [["block_name", &"get_var_PinSound"], ["label", "Param"], ["color", Color(1, 0.560784, 0.0313726, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["scope", ""], ["block_format", "PinSound"], ["statement", "PinSound"], ["defaults", {}], ["variant_type", 2], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_5b732"]
-script = ExtResource("3_vuinq")
-name = &"get_var_PinSound"
-position = Vector2(0, 0)
-path_child_pairs = []
-block_serialized_properties = SubResource("Resource_sssdn")
-
-[sub_resource type="Resource" id="Resource_d8iva"]
-script = ExtResource("3_vuinq")
-name = &"play_sound"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_5b732")]]
-block_serialized_properties = SubResource("Resource_ohsst")
-
-[sub_resource type="Resource" id="Resource_4c6ia"]
+[sub_resource type="Resource" id="Resource_ywt3n"]
 script = ExtResource("3_vuinq")
 name = &"set_var_PinSound"
-position = Vector2(20, 0)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_8jrgs")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_d8iva")]]
-block_serialized_properties = SubResource("Resource_fi5gb")
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"value": SubResource("Resource_qfehw")
+}
 
-[sub_resource type="Resource" id="Resource_6gc6v"]
+[sub_resource type="Resource" id="Resource_8uj1t"]
+script = ExtResource("5_x7mnm")
+name = &"get_var_PinSound"
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_p5iib"]
+script = ExtResource("5_x7mnm")
+name = &"compare"
+arguments = {
+"float1": SubResource("Resource_8uj1t"),
+"float2": 1.0,
+"op": "=="
+}
+
+[sub_resource type="Resource" id="Resource_1ga4u"]
+script = ExtResource("3_vuinq")
+name = &"play_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"db": 0.0,
+"name": "1",
+"pitch": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_uk0hu"]
 script = ExtResource("3_vuinq")
 name = &"if"
-position = Vector2(0, 0)
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_cg7n0")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_4c6ia")]]
-block_serialized_properties = SubResource("Resource_y65b0")
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_1ga4u")])
+arguments = {
+"condition": SubResource("Resource_p5iib")
+}
 
-[sub_resource type="Resource" id="Resource_g3s5b"]
+[sub_resource type="Resource" id="Resource_1wx3d"]
+script = ExtResource("5_x7mnm")
+name = &"get_var_PinSound"
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_ha3he"]
+script = ExtResource("5_x7mnm")
+name = &"compare"
+arguments = {
+"float1": SubResource("Resource_1wx3d"),
+"float2": 2.0,
+"op": "=="
+}
+
+[sub_resource type="Resource" id="Resource_2yo7g"]
+script = ExtResource("3_vuinq")
+name = &"play_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"db": 0.0,
+"name": "2",
+"pitch": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_npgfi"]
+script = ExtResource("3_vuinq")
+name = &"else_if"
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_2yo7g")])
+arguments = {
+"condition": SubResource("Resource_ha3he")
+}
+
+[sub_resource type="Resource" id="Resource_orhil"]
+script = ExtResource("5_x7mnm")
+name = &"get_var_PinSound"
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_mklnr"]
+script = ExtResource("5_x7mnm")
+name = &"compare"
+arguments = {
+"float1": SubResource("Resource_orhil"),
+"float2": 3.0,
+"op": "=="
+}
+
+[sub_resource type="Resource" id="Resource_7bqcv"]
+script = ExtResource("3_vuinq")
+name = &"play_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"db": 0.0,
+"name": "3",
+"pitch": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_cndf2"]
+script = ExtResource("3_vuinq")
+name = &"else_if"
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_7bqcv")])
+arguments = {
+"condition": SubResource("Resource_mklnr")
+}
+
+[sub_resource type="Resource" id="Resource_8sayb"]
+script = ExtResource("5_x7mnm")
+name = &"get_var_PinSound"
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_h1r8e"]
+script = ExtResource("5_x7mnm")
+name = &"compare"
+arguments = {
+"float1": SubResource("Resource_8sayb"),
+"float2": 4.0,
+"op": "=="
+}
+
+[sub_resource type="Resource" id="Resource_f0lr5"]
+script = ExtResource("3_vuinq")
+name = &"play_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"db": 0.0,
+"name": "4",
+"pitch": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_fct40"]
+script = ExtResource("3_vuinq")
+name = &"else_if"
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_f0lr5")])
+arguments = {
+"condition": SubResource("Resource_h1r8e")
+}
+
+[sub_resource type="Resource" id="Resource_vfjo3"]
+script = ExtResource("3_vuinq")
+name = &"play_sound"
+children = Array[ExtResource("3_vuinq")]([])
+arguments = {
+"db": 0.0,
+"name": "5",
+"pitch": 1.0
+}
+
+[sub_resource type="Resource" id="Resource_7ybnm"]
+script = ExtResource("3_vuinq")
+name = &"else"
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_vfjo3")])
+arguments = {}
+
+[sub_resource type="Resource" id="Resource_hv7wq"]
+script = ExtResource("3_vuinq")
+name = &"if"
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_ywt3n"), SubResource("Resource_uk0hu"), SubResource("Resource_npgfi"), SubResource("Resource_cndf2"), SubResource("Resource_fct40"), SubResource("Resource_7ybnm")])
+arguments = {
+"condition": SubResource("Resource_gogqm")
+}
+
+[sub_resource type="Resource" id="Resource_u7dav"]
 script = ExtResource("3_vuinq")
 name = &"area2d_on_entered"
-position = Vector2(50, 325)
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterOutput0/SnapPoint"), SubResource("Resource_1mt8y")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_6gc6v")]]
-block_serialized_properties = SubResource("Resource_c6g8w")
+children = Array[ExtResource("3_vuinq")]([SubResource("Resource_hv7wq")])
+arguments = {}
 
-[sub_resource type="Resource" id="Resource_4jj8k"]
-script = ExtResource("6_0s6jk")
+[sub_resource type="Resource" id="Resource_jwmn8"]
+script = ExtResource("3_arw1h")
+root = SubResource("Resource_u7dav")
+canvas_position = Vector2(950, 50)
+
+[sub_resource type="Resource" id="Resource_2852e"]
+script = ExtResource("7_gyajk")
 var_name = "PinSound"
 var_type = 2
 
-[sub_resource type="Resource" id="Resource_y71on"]
+[sub_resource type="Resource" id="Resource_lf2qw"]
 script = ExtResource("5_3jwsj")
 script_inherits = "Area2D"
-block_trees = Array[ExtResource("3_vuinq")]([SubResource("Resource_1h6wi"), SubResource("Resource_g3s5b")])
-variables = Array[ExtResource("6_0s6jk")]([SubResource("Resource_4jj8k")])
+block_serialization_trees = Array[ExtResource("3_arw1h")]([SubResource("Resource_cqan1"), SubResource("Resource_jwmn8")])
+variables = Array[ExtResource("7_gyajk")]([SubResource("Resource_2852e")])
 generated_script = "extends Area2D
 
 var PinSound: int
 
+
+func _init():
+	body_entered.connect(_on_body_entered)
 
 func _ready():
 	var __sound_1 = AudioStreamPlayer.new()
 	__sound_1.name = '1'
 	__sound_1.set_stream(load('res://game-04/Sounds/Muted 1.ogg'))
 	add_child(__sound_1)
+
 	var __sound_2 = AudioStreamPlayer.new()
 	__sound_2.name = '2'
 	__sound_2.set_stream(load('res://game-04/Sounds/Muted 2.ogg'))
 	add_child(__sound_2)
+
 	var __sound_3 = AudioStreamPlayer.new()
 	__sound_3.name = '3'
 	__sound_3.set_stream(load('res://game-04/Sounds/Muted 3.ogg'))
 	add_child(__sound_3)
+
 	var __sound_4 = AudioStreamPlayer.new()
 	__sound_4.name = '4'
 	__sound_4.set_stream(load('res://game-04/Sounds/Muted 4.ogg'))
 	add_child(__sound_4)
+
 	var __sound_5 = AudioStreamPlayer.new()
 	__sound_5.name = '5'
 	__sound_5.set_stream(load('res://game-04/Sounds/Muted 5.ogg'))
 	add_child(__sound_5)
 
-func _on_body_entered(body: Node2D):
 
-	if body.is_in_group('Ball'):
-		PinSound = randi_range(1, 5)
-		var __sound_node_1 = get_node(str(PinSound))
-		__sound_node_1.volume_db = 0
-		__sound_node_1.pitch_scale = 1
-		__sound_node_1.play()
+func _on_body_entered(something: Node2D):
 
-func _init():
-	body_entered.connect(_on_body_entered)
+	if ((something).is_in_group('Ball')):
+		PinSound = (randi_range(1, 5))
+		if ((PinSound) == 1):
+			var __sound_node_1 = get_node('1')
+			__sound_node_1.volume_db = 0
+			__sound_node_1.pitch_scale = 1
+			__sound_node_1.play()
+
+		elif ((PinSound) == 2):
+			var __sound_node_2 = get_node('2')
+			__sound_node_2.volume_db = 0
+			__sound_node_2.pitch_scale = 1
+			__sound_node_2.play()
+
+		elif ((PinSound) == 3):
+			var __sound_node_3 = get_node('3')
+			__sound_node_3.volume_db = 0
+			__sound_node_3.pitch_scale = 1
+			__sound_node_3.play()
+
+		elif ((PinSound) == 4):
+			var __sound_node_4 = get_node('4')
+			__sound_node_4.volume_db = 0
+			__sound_node_4.pitch_scale = 1
+			__sound_node_4.play()
+
+		else:
+			var __sound_node_5 = get_node('5')
+			__sound_node_5.volume_db = 0
+			__sound_node_5.pitch_scale = 1
+			__sound_node_5.play()
+
+
 "
 version = 0
 
@@ -293,4 +363,4 @@ debug_color = Color(0.996078, 0, 0.219608, 0.113725)
 
 [node name="BlockCode" type="Node" parent="SoundArea"]
 script = ExtResource("2_24vdh")
-block_script = SubResource("Resource_y71on")
+block_script = SubResource("Resource_lf2qw")

--- a/project.godot
+++ b/project.godot
@@ -50,6 +50,7 @@ camera_zoom_animation=""
 peew_ani=""
 ship_hit_animation=""
 tutorial_animations=""
+Ball=""
 
 [input]
 


### PR DESCRIPTION
This was mainly a direct reimplementation of each BlockCode program, with a few tweaks. I had to make the Ball group global so that it shows up in the “[something] is in group [group ▼]” dropdown. I also added an extra Reset method on the "Bump!" label to hide it when the game resets, calling it directly with "call [method] on [node]".

The code that plays one of 5 sounds at random when the ball hits a pin
previously relied on being able to pass an int as the "sound name" parameter,
which would for some reason I didn't bother digging into would previously cause
a str() conversion to be inserted, but now does not.

```gdscript
func _on_body_entered(body: Node2D):
    if body.is_in_group('Ball'):
            PinSound = randi_range(1, 5)
            var __sound_node_1 = get_node(str(PinSound))
            # ...
```

So instead I use a chain of conditionals that compiles to:

```gdscript
func _on_body_entered(something: Node2D):
    if ((something).is_in_group('Ball')):
            PinSound = randi_range(1, 5)
            if PinSound == 1:
                    var __sound_node_1 = get_node('1')
                    # ...
            elif PinSound == 2:
                    # ...
```

This is a bit wordier than what was there before but it works.

It would be nice to have a way to define a local variable rather than a
property of the node, but it's not the end of the world.

https://phabricator.endlessm.com/T35697