### PR TITLE
ci: Cancel running workflows if retriggered

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,6 +5,11 @@ on:
     types:
       - published
 
+# Cancel any ongoing previous run if the job is re-triggered
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -3,6 +3,11 @@ on:
     types:
       - published
 
+# Cancel any ongoing previous run if the job is re-triggered
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 name: Push to Godot Asset Library
 
 jobs:


### PR DESCRIPTION
For rationale, see
<https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions>.

For the GitHub Pages and Godot Asset Library actions, each run overwrites the result of any previous run, so the concurrency group is just the workflow name.